### PR TITLE
Simplify VPP package definition

### DIFF
--- a/pkgs/os-specific/linux/vpp/default.nix
+++ b/pkgs/os-specific/linux/vpp/default.nix
@@ -71,10 +71,6 @@ stdenv.mkDerivation rec {
       cp -r build-root/install-vpp-native/$subdir/* $out/
     done
 
-    # Copy across missing header files; ugh.
-    mkdir -p $out/include/vlibsocket
-    cp -r src/vlibsocket/*.h $out/include/vlibsocket/
-
     # Replace rpath.
     build_rpath=$(pwd)/build-root/install-vpp-native/vpp/lib
     for f in $(find $out/bin -type f -print) $(find $out/lib -name '*.so*' -print); do


### PR DESCRIPTION
Use a fixed revision from the VPP repository.  Include the revision in
the Nix version name.

Before building, patch the source to replace /usr/lib references for
plugin paths with references into the store.

Rewrite build phase.

Rewrite install phase to be less ad-hoc.

Make VPP look for plugins in its install dir.

Remove installation of headers that are no longer needed.